### PR TITLE
Cosign container and binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   release:
@@ -23,6 +24,8 @@ jobs:
         uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # tag=v3.0.0
         with:
           go-version: "${{ steps.gover.outputs.goversion }}"
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25 # tag=v2.4.0
       - uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # tag=v2.0.0
         with:
           registry: ghcr.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,6 @@ jobs:
         with:
           distribution: goreleaser
           version: v1.8.3
-          args: release --rm-dist
+          args: release --rm-dist --parallelism=1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,7 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: "cosign sign-blob --verbose --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
-          output: true
+        - cmd: "cosign sign-blob --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
           env:
             - COSIGN_EXPERIMENTAL=1
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - ghcr.io/thepwagner/hansel:{{ .Version }}-amd64
+      - ghcr.io/shopify/hansel:{{ .Version }}-amd64
     build_flag_templates:
       - --platform=linux/amd64
       - --no-cache
@@ -41,7 +41,7 @@ dockers:
   - <<: *docker
     goarch: arm64
     image_templates:
-      - ghcr.io/thepwagner/hansel:{{ .Version }}-arm64
+      - ghcr.io/shopify/hansel:{{ .Version }}-arm64
     build_flag_templates:
       - --platform=linux/arm64/v8
       - --no-cache
@@ -55,14 +55,14 @@ dockers:
       - --label=org.opencontainers.image.licenses=MIT
 
 docker_manifests:
-  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}
+  - name_template: ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}
     image_templates:
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
-  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:latest
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
+  - name_template: ghcr.io/shopify/{{ .ProjectName }}:latest
     image_templates:
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - ghcr.io/thepwagner/hansel:{{ .Version }}-amd64
+      - ghcr.io/shopify/hansel:{{ .Version }}-amd64
     build_flag_templates:
       - --platform=linux/amd64
       - --no-cache
@@ -40,7 +40,7 @@ dockers:
   - <<: *docker
     goarch: arm64
     image_templates:
-      - ghcr.io/thepwagner/hansel:{{ .Version }}-arm64
+      - ghcr.io/shopify/hansel:{{ .Version }}-arm64
     build_flag_templates:
       - --platform=linux/arm64/v8
       - --no-cache
@@ -54,14 +54,14 @@ dockers:
       - --label=org.opencontainers.image.licenses=MIT
 
 docker_manifests:
-  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}
+  - name_template: ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}
     image_templates:
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
-  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:latest
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
+  - name_template: ghcr.io/shopify/{{ .ProjectName }}:latest
     image_templates:
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,11 +10,14 @@ builds:
       - arm64
     hooks:
       post:
-        - sh -c "COSIGN_EXPERIMENTAL=1 cosign sign-blob --output dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
+        - cmd: "cosign sign-blob --output dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
+          output: true
+          env:
+            - COSIGN_EXPERIMENTAL=1
 
 release:
   extra_files:
-  - glob: dist/*.sig
+    - glob: dist/*.sig
 
 dockers:
   - &docker
@@ -62,11 +65,11 @@ docker_manifests:
       - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
 
 docker_signs:
-- cmd: cosign
-  env:
-  - COSIGN_EXPERIMENTAL=1
-  artifacts: manifests
-  output: true
-  args:
-  - 'sign'
-  - '${artifact}'
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    artifacts: manifests
+    output: true
+    args:
+      - "sign"
+      - "${artifact}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: "cosign sign-blob --output dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
+        - cmd: "cosign sign-blob --verbose --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
           output: true
           env:
             - COSIGN_EXPERIMENTAL=1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,13 @@ builds:
     goarch:
       - amd64
       - arm64
+    hooks:
+      post:
+        - sh -c "COSIGN_EXPERIMENTAL=1 cosign sign-blob --output dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
+
+release:
+  extra_files:
+  - glob: dist/*.sig
 
 dockers:
   - &docker

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,13 +10,14 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: "cosign sign-blob --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Target }}.sig {{ .Path }}"
+        - cmd: "cosign sign-blob --output-certificate dist/{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}-keyless.pem --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}-keyless.sig {{ .Path }}"
           env:
             - COSIGN_EXPERIMENTAL=1
 
 release:
   extra_files:
     - glob: dist/*.sig
+    - glob: dist/*.pem
 
 dockers:
   - &docker

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - ghcr.io/shopify/hansel:{{ .Version }}-amd64
+      - ghcr.io/thepwagner/hansel:{{ .Version }}-amd64
     build_flag_templates:
       - --platform=linux/amd64
       - --no-cache
@@ -38,7 +38,7 @@ dockers:
   - <<: *docker
     goarch: arm64
     image_templates:
-      - ghcr.io/shopify/hansel:{{ .Version }}-arm64
+      - ghcr.io/thepwagner/hansel:{{ .Version }}-arm64
     build_flag_templates:
       - --platform=linux/arm64/v8
       - --no-cache
@@ -52,14 +52,14 @@ dockers:
       - --label=org.opencontainers.image.licenses=MIT
 
 docker_manifests:
-  - name_template: ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}
+  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}
     image_templates:
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
-  - name_template: ghcr.io/shopify/{{ .ProjectName }}:latest
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
+  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:latest
     image_templates:
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
 
 docker_signs:
 - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: "cosign sign-blob --output-certificate dist/{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}-keyless.pem --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}-keyless.sig {{ .Path }}"
+        - cmd: "cosign sign-blob --output-certificate dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}-keyless.pem --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}-keyless.sig {{ .Path }}"
           env:
             - COSIGN_EXPERIMENTAL=1
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - ghcr.io/shopify/hansel:{{ .Version }}-amd64
+      - ghcr.io/thepwagner/hansel:{{ .Version }}-amd64
     build_flag_templates:
       - --platform=linux/amd64
       - --no-cache
@@ -41,7 +41,7 @@ dockers:
   - <<: *docker
     goarch: arm64
     image_templates:
-      - ghcr.io/shopify/hansel:{{ .Version }}-arm64
+      - ghcr.io/thepwagner/hansel:{{ .Version }}-arm64
     build_flag_templates:
       - --platform=linux/arm64/v8
       - --no-cache
@@ -55,14 +55,14 @@ dockers:
       - --label=org.opencontainers.image.licenses=MIT
 
 docker_manifests:
-  - name_template: ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}
+  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}
     image_templates:
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
-  - name_template: ghcr.io/shopify/{{ .ProjectName }}:latest
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
+  - name_template: ghcr.io/thepwagner/{{ .ProjectName }}:latest
     image_templates:
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
-      - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-amd64
+      - ghcr.io/thepwagner/{{ .ProjectName }}:{{ .Version }}-arm64
 
 docker_signs:
   - cmd: cosign

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,3 +53,13 @@ docker_manifests:
     image_templates:
       - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-amd64
       - ghcr.io/shopify/{{ .ProjectName }}:{{ .Version }}-arm64
+
+docker_signs:
+- cmd: cosign
+  env:
+  - COSIGN_EXPERIMENTAL=1
+  artifacts: manifests
+  output: true
+  args:
+  - 'sign'
+  - '${artifact}'


### PR DESCRIPTION
Use cosign+fulcio to sign the containers and binaries generated from the release process.

I've tested this in https://github.com/thepwagner/hansel , and this PR include the "receipts" from that experimentation. I'll be sure to squash.

You can verify the container:
```
$ COSIGN_EXPERIMENTAL=1 cosign verify ghcr.io/thepwagner/hansel:0.0.9 | jq
```
* The `.[].critical.image."docker-manifest-digest"` should match what you see at https://github.com/users/thepwagner/packages/container/hansel/26575582?tag=0.0.9
* The `'.[].optional | .Issuer, .Subject'` should indicate this certificate was granted to the GitHub Actions workflow that produced the image.


You can verify the blobs:
```
$ curl -sOL https://github.com/thepwagner/hansel/releases/download/v0.0.9/hansel_0.0.9_linux_amd64.tar.gz
$ tar xvf hansel_0.0.9_linux_amd64.tar.gz
LICENSE
README.md
hansel

$ curl -sOL https://github.com/thepwagner/hansel/releases/download/v0.0.9/hansel_0.0.9_linux_amd64-keyless.sig
$ curl -sOL https://github.com/thepwagner/hansel/releases/download/v0.0.9/hansel_0.0.9_linux_amd64-keyless.pem
$ COSIGN_EXPERIMENTAL=1 cosign verify-blob --signature hansel_0.0.9_linux_amd64-keyless.sig --certificate hansel_0.0.9_linux_amd64-keyless.pem --enforce-sct hansel
$ base64 -d hansel_0.0.9_linux_amd64-keyless.pem | openssl x509 -text
```
* You should see the `cosign verify-blob` state `Verified OK` for the signature.
* From the openssl output, you should se:
   * The key was issued by `O = sigstore.dev, CN = sigstore-intermediate`
   * The certificate was only valid for a 10 minute window while the workflow ran
   * A bunch of x509 extensions linking the certificate to the triggering Actions workflow+event.
