### PR TITLE
go 1.18.4

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.18.3 AS deb
+FROM golang:1.18.4 AS deb
 WORKDIR /app
 COPY go.mod .
 COPY go.sum .
@@ -8,7 +8,7 @@ ENV HANSEL_TEST_DEBIAN=true
 RUN [ "go", "test", "-v", "./internal/cli/...", "-run", "TestGenerate_InstallDebian" ]
 
 # This line also determines the golang version used for GitHub Actions CI
-FROM golang:1.18.3-alpine AS apk
+FROM golang:1.18.4-alpine AS apk
 ENV CGO_ENABLED=0
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Thanks https://github.com/Shopify/hansel/pull/24 for the reminder, but we don't want to use `go1.19rc`.