### PR TITLE
dependabot: github-actions too

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,3 +12,9 @@ updates:
       interval: "daily"
     reviewers:
       - "Shopify/infrasec"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "Shopify/infrasec"


### PR DESCRIPTION
Let's get PRs when new versions of Actions become available.

(We fell behind in `cosign-installer`).

Reference https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem