### PR TITLE
sign-blob -y

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,9 +10,7 @@ builds:
       - arm64
     hooks:
       post:
-        - cmd: "cosign sign-blob --output-certificate dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}-keyless.pem --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}-keyless.sig {{ .Path }}"
-          env:
-            - COSIGN_EXPERIMENTAL=1
+        - cmd: "cosign sign-blob --yes --output-certificate dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}-keyless.pem --output-signature dist/{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}-keyless.sig {{ .Path }}"
 
 release:
   extra_files:
@@ -66,8 +64,6 @@ docker_manifests:
 
 docker_signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     artifacts: manifests
     output: true
     args:


### PR DESCRIPTION
Uninformed attempt at fixing `cosign` in the release build - this is a blocker locally that I may have missed in the `cosign-2.0.0` release notes.

Drop `COSIGN_EXPERIMENTAL=1`, since that was definitely in the `cosign-2.0.0` release notes.

# Related
- #101 
- https://github.com/sigstore/cosign/blob/main/CHANGELOG.md#v200