### PR TITLE
cosign sign -y

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,4 +68,5 @@ docker_signs:
     output: true
     args:
       - "sign"
+      - "--yes"
       - "${artifact}"


### PR DESCRIPTION
Repeating #103 ; which seems to have been the right thing 🤞 , but also needs to be applied to the `cosign sign` docker step (not just the `cosign sign-blob` binary signing).

# Related
- #103 
- #101