### PR TITLE
scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,19 @@
+name: OpenSSF Scorecard
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'
+  push:
+    branches: main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    permissions:
+      contents: read
+      id-token: write
+    uses: Shopify/github-workflows/.github/workflows/scorecard.yaml@c395c2cfd65be9a36f5dcfd21f4a2498a477fed4 # v0.0.6
+    secrets:
+      token: ${{secrets.SCORECARD_TOKEN}}


### PR DESCRIPTION
Manually creating a workflow to publish an OpenSSF scorecard. We want hansel's users to be assured of our security practices, and scorecards offer us a way to measure and demonstrate.

This uses a shared workflow in https://github.com/Shopify/github-workflows to centralize how the scorecard is created and published, we only provide that workflow with permission to:
* Clone this repository (`contents:read`), so it has a local copy of the source to inspect
* Leverage the Actions OIDC token (`id-token: write`), so it can publish results to the Scorecards service

We pass an organization-level `SCORECARD_TOKEN` as an argument, which grants `administration:read` permissions that aren't available to Actions by default. This allows the scorecard action to inspect branch protection settings of the repository, and include that in the generated results.

## Testing instructions

~We could remove the branch filter from the `push` trigger to test this in a branch.~ The action requires it be run from the default branch. It will first run when the PR is merged (and ideally subsequently as it shames me into improving branch protection settings 😆 ).

