### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Shopify/infrasec


### PR DESCRIPTION
In #156 we started tracking our OpenSSF scorecards.

The scorecard rightfully points out that while we have branch protection enabled, we're not using `CODEOWNERS` to require a review. This seems like a good idea.
