### PR TITLE
README: add scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hansel
 
+![OpenSSF Scorecard Badge](https://api.securityscorecards.dev/projects/github.com/Shopify/hansel/badge)
+
 Hansel generates empty linux packages. These packages can be installed to track dependencies manually added to a container image.
 
 [![Usage example](https://asciinema.org/a/497735.svg)](https://asciinema.org/a/497735)


### PR DESCRIPTION
Adding a scorecard badge.

## Testing instructions

View https://github.com/Shopify/hansel/tree/scorecard-badge#hansel

# Related

- Depends https://github.com/Shopify/hansel/pull/156

