### PR TITLE
release: shift permissions to job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,14 +4,15 @@ on:
   push:
     tags: [ 'v*.*.*' ]
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3


### PR DESCRIPTION
This should have no effective changes, but I think it will improve the OpenSSF Scorecard result.

Workflow level permissions are called "top level" permissions and are calculated around here: https://github.com/ossf/scorecard/blob/8779de9cd23ffe15b6fd398a2f125a3452f08170/checks/raw/permissions.go#L267
Write permissions at the top level seem to be discouraaged.

Individual workflows are inspected for actions that fingerprint - I think because our workflow includes `actions/setup-go` and `goreleaser/goreleaser-action`, it will be considered to require the `contents: write` and `packages: write` permissions. This is calculated around here - https://github.com/ossf/scorecard/blob/8779de9cd23ffe15b6fd398a2f125a3452f08170/checks/raw/permissions.go#L336-L351

TLDR: should not break anything, might boost scorecard by 0.1 📈

# Related

- Reference https://goreleaser.com/ci/actions/#token-permissions

