### PR TITLE
goreleaser: apk+deb too

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,3 +71,13 @@ docker_signs:
       - "sign"
       - "--yes"
       - "${artifact}"
+
+nfpms:
+  - id: goreleaser
+    maintainer: "Shopify <admins@shopify.com>"
+    description: "Generates empty packages, as breadcrumbs to mark supply chain debt."
+    license: "MIT"
+    homepage: "https://github.com/Shopify/hansel"
+    formats:
+      - apk
+      - deb


### PR DESCRIPTION
Encourage `hansel` itself to appear in the package lists that `hansel` is "writing" to.

This avoids the ironic pattern of needing to use hansel after adding hansel to an image.

