### PR TITLE
Update cla.yml

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,6 +12,7 @@ jobs:
   cla:
     uses: Shopify/github-workflows/.github/workflows/cla.yaml@0b6f7f7def1c8f895fd31cd4183f98e3562458e9 # v0.2.0
     permissions:
+      actions: write
       pull-requests: write
     secrets:
       token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
According to https://github.com/Shopify/github-workflows/blob/cc6715f60f96d886e6117711c9c6e4fa964fc320/.github/workflows/cla.yaml#L29 , this is used to re-trigger workflows.

I'm not 100% - but apparently I made the change - https://github.com/Shopify/github-workflows/pull/8

# Related

- Discovered https://github.com/Shopify/hansel/pull/349