### PR TITLE
urfave-cli v3

### DIFF
--- a/cmd/hansel/main.go
+++ b/cmd/hansel/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 
@@ -11,7 +12,7 @@ func main() {
 	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 	app := cli.NewApp(log)
-	if err := app.Run(os.Args); err != nil {
+	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Error("encountered error", "error", err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/hansel
 
-go 1.23.0
+go 1.24
 
 toolchain go1.24.1
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/goreleaser/nfpm/v2 v2.43.0
 	github.com/stretchr/testify v1.10.0
-	github.com/urfave/cli/v2 v2.27.6
+	github.com/urfave/cli/v3 v3.3.8
 	golang.org/x/sync v0.15.0
 )
 
@@ -22,7 +22,6 @@ require (
 	github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb // indirect
 	github.com/cavaliergopher/cpio v1.0.1 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
@@ -44,14 +43,12 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/ulikunitz/xz v0.5.12 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	gitlab.com/digitalxero/go-conventional-commit v1.0.7 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/cavaliergopher/cpio v1.0.1 h1:KQFSeKmZhv0cr+kawA3a0xTQCU4QxXF1vhU7P7a
 github.com/cavaliergopher/cpio v1.0.1/go.mod h1:pBdaqQjnvXxdS/6CvNDwIANIFSP0xRKI16PX4xejRQc=
 github.com/cloudflare/circl v1.6.0 h1:cr5JKic4HI+LkINy2lg3W2jF8sHCVTBncJr5gIIq7qk=
 github.com/cloudflare/circl v1.6.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
-github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
-github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -107,8 +105,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sassoftware/go-rpmutils v0.4.0 h1:ojND82NYBxgwrV+mX1CWsd5QJvvEZTKddtCdFLPWhpg=
 github.com/sassoftware/go-rpmutils v0.4.0/go.mod h1:3goNWi7PGAT3/dlql2lv3+MSN5jNYPjT5mVcQcIsYzI=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
@@ -131,14 +127,12 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/urfave/cli/v2 v2.27.6 h1:VdRdS98FNhKZ8/Az8B7MTyGQmpIr36O1EHybx/LaZ4g=
-github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
+github.com/urfave/cli/v3 v3.3.8 h1:BzolUExliMdet9NlJ/u4m5vHSotJ3PzEqSAZ1oPMa/E=
+github.com/urfave/cli/v3 v3.3.8/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
-github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
-github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 gitlab.com/digitalxero/go-conventional-commit v1.0.7 h1:8/dO6WWG+98PMhlZowt/YjuiKhqhGlOCwlIV8SqqGh8=
 gitlab.com/digitalxero/go-conventional-commit v1.0.7/go.mod h1:05Xc2BFsSyC5tKhK0y+P3bs0AwUtNuTp+mTpbCU/DZ0=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3,11 +3,11 @@ package cli
 import (
 	"log/slog"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
-func NewApp(log *slog.Logger) *cli.App {
-	return &cli.App{
+func NewApp(log *slog.Logger) *cli.Command {
+	return &cli.Command{
 		Name:            "hansel",
 		Usage:           "create empty packages as breadcrumbs for use when auditing container contents",
 		Flags:           GenerateFlags,

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -21,7 +21,7 @@ func TestGenerate_NoPackagers(t *testing.T) {
 	}
 	cmd := newCliCommand(t)
 
-	err := cli.Generate(slog.Default())(context.Background(), cmd)
+	err := cli.Generate(slog.Default())(t.Context(), cmd)
 	assert.EqualError(t, err, "no packager(s) specified")
 }
 
@@ -29,7 +29,7 @@ func TestGenerate_InvalidPackage(t *testing.T) {
 	cmd := newCliCommand(t)
 	cmd.Set(cli.FlagPkgName, "")
 
-	err := cli.Generate(slog.Default())(context.Background(), cmd)
+	err := cli.Generate(slog.Default())(t.Context(), cmd)
 	assert.EqualError(t, err, "validating package info: package name must be provided")
 }
 
@@ -43,7 +43,7 @@ func TestGenerate_Directory(t *testing.T) {
 	cmd.Set(cli.FlagOutRpm, "true")
 	cmd.Set(cli.FlagPkgArch, "amd64")
 
-	err := cli.Generate(slog.Default())(context.Background(), cmd)
+	err := cli.Generate(slog.Default())(t.Context(), cmd)
 	require.NoError(t, err)
 
 	dir, err := os.ReadDir(tmpDir)
@@ -70,7 +70,7 @@ func TestGenerate_Filename(t *testing.T) {
 	cmd.Set(cli.FlagOutFilename, "hansel-breadcrumb.apk")
 	cmd.Set(cli.FlagPkgArch, "amd64")
 
-	err := cli.Generate(slog.Default())(context.Background(), cmd)
+	err := cli.Generate(slog.Default())(t.Context(), cmd)
 	require.NoError(t, err)
 
 	dir, err := os.ReadDir(tmpDir)
@@ -95,7 +95,7 @@ func TestGenerate_InstallDebian(t *testing.T) {
 	cmd := newCliCommand(t)
 	cmd.Set(cli.FlagInstall, "true")
 
-	err := cli.Generate(slog.Default())(context.Background(), cmd)
+	err := cli.Generate(slog.Default())(t.Context(), cmd)
 	require.NoError(t, err)
 
 	out, err := exec.Command("dpkg", "-s", "hansel-breadcrumb").CombinedOutput()
@@ -114,7 +114,7 @@ func TestGenerate_InstallAlpine(t *testing.T) {
 	cmd := newCliCommand(t)
 	cmd.Set(cli.FlagInstall, "true")
 
-	err := cli.Generate(slog.Default())(context.Background(), cmd)
+	err := cli.Generate(slog.Default())(t.Context(), cmd)
 	require.NoError(t, err)
 
 	out, err := exec.Command("apk", "info", "hansel-breadcrumb").CombinedOutput()

--- a/internal/cli/generate_test.go
+++ b/internal/cli/generate_test.go
@@ -1,7 +1,7 @@
 package cli_test
 
 import (
-	"flag"
+	"context"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -12,38 +12,38 @@ import (
 	"github.com/Shopify/hansel/internal/cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	urfave "github.com/urfave/cli/v2"
+	urfave "github.com/urfave/cli/v3"
 )
 
 func TestGenerate_NoPackagers(t *testing.T) {
 	if runtime.GOOS == "linux" {
 		t.Skip("linux will detect a packager automatically")
 	}
-	cliCtx := newCliContext(t)
+	cmd := newCliCommand(t)
 
-	err := cli.Generate(slog.Default())(cliCtx)
+	err := cli.Generate(slog.Default())(context.Background(), cmd)
 	assert.EqualError(t, err, "no packager(s) specified")
 }
 
 func TestGenerate_InvalidPackage(t *testing.T) {
-	cliCtx := newCliContext(t)
-	cliCtx.Set(cli.FlagPkgName, "")
+	cmd := newCliCommand(t)
+	cmd.Set(cli.FlagPkgName, "")
 
-	err := cli.Generate(slog.Default())(cliCtx)
+	err := cli.Generate(slog.Default())(context.Background(), cmd)
 	assert.EqualError(t, err, "validating package info: package name must be provided")
 }
 
 func TestGenerate_Directory(t *testing.T) {
 	// Output every type of package to a temp dir:
-	cliCtx := newCliContext(t)
+	cmd := newCliCommand(t)
 	tmpDir := t.TempDir()
-	cliCtx.Set(cli.FlagOutDirectory, tmpDir)
-	cliCtx.Set(cli.FlagOutApk, "true")
-	cliCtx.Set(cli.FlagOutDeb, "true")
-	cliCtx.Set(cli.FlagOutRpm, "true")
-	cliCtx.Set(cli.FlagPkgArch, "amd64")
+	cmd.Set(cli.FlagOutDirectory, tmpDir)
+	cmd.Set(cli.FlagOutApk, "true")
+	cmd.Set(cli.FlagOutDeb, "true")
+	cmd.Set(cli.FlagOutRpm, "true")
+	cmd.Set(cli.FlagPkgArch, "amd64")
 
-	err := cli.Generate(slog.Default())(cliCtx)
+	err := cli.Generate(slog.Default())(context.Background(), cmd)
 	require.NoError(t, err)
 
 	dir, err := os.ReadDir(tmpDir)
@@ -64,13 +64,13 @@ func TestGenerate_Directory(t *testing.T) {
 }
 
 func TestGenerate_Filename(t *testing.T) {
-	cliCtx := newCliContext(t)
+	cmd := newCliCommand(t)
 	tmpDir := t.TempDir()
-	cliCtx.Set(cli.FlagOutDirectory, tmpDir)
-	cliCtx.Set(cli.FlagOutFilename, "hansel-breadcrumb.apk")
-	cliCtx.Set(cli.FlagPkgArch, "amd64")
+	cmd.Set(cli.FlagOutDirectory, tmpDir)
+	cmd.Set(cli.FlagOutFilename, "hansel-breadcrumb.apk")
+	cmd.Set(cli.FlagPkgArch, "amd64")
 
-	err := cli.Generate(slog.Default())(cliCtx)
+	err := cli.Generate(slog.Default())(context.Background(), cmd)
 	require.NoError(t, err)
 
 	dir, err := os.ReadDir(tmpDir)
@@ -92,10 +92,10 @@ func TestGenerate_InstallDebian(t *testing.T) {
 		t.Skip("use Dockerfile.test")
 	}
 
-	cliCtx := newCliContext(t)
-	cliCtx.Set(cli.FlagInstall, "true")
+	cmd := newCliCommand(t)
+	cmd.Set(cli.FlagInstall, "true")
 
-	err := cli.Generate(slog.Default())(cliCtx)
+	err := cli.Generate(slog.Default())(context.Background(), cmd)
 	require.NoError(t, err)
 
 	out, err := exec.Command("dpkg", "-s", "hansel-breadcrumb").CombinedOutput()
@@ -111,10 +111,10 @@ func TestGenerate_InstallAlpine(t *testing.T) {
 		t.Skip("use Dockerfile.test")
 	}
 
-	cliCtx := newCliContext(t)
-	cliCtx.Set(cli.FlagInstall, "true")
+	cmd := newCliCommand(t)
+	cmd.Set(cli.FlagInstall, "true")
 
-	err := cli.Generate(slog.Default())(cliCtx)
+	err := cli.Generate(slog.Default())(context.Background(), cmd)
 	require.NoError(t, err)
 
 	out, err := exec.Command("apk", "info", "hansel-breadcrumb").CombinedOutput()
@@ -123,16 +123,33 @@ func TestGenerate_InstallAlpine(t *testing.T) {
 	assert.Contains(t, string(out), "hansel-breadcrumb-1.0.0")
 }
 
-func newCliContext(tb testing.TB) *urfave.Context {
+func newCliCommand(tb testing.TB) *urfave.Command {
 	tb.Helper()
 
-	flags := flag.NewFlagSet("", flag.ContinueOnError)
-	for _, f := range cli.GenerateFlags {
-		f.Apply(flags)
+	// In v3, we need to run the command with the flags to have them available
+	// We'll create a wrapper command that captures the parsed state
+	var capturedCmd *urfave.Command
+	wrapperCmd := &urfave.Command{
+		Name:  "test",
+		Flags: cli.GenerateFlags,
+		Action: func(ctx context.Context, c *urfave.Command) error {
+			capturedCmd = c
+			return nil
+		},
 	}
-	cliCtx := urfave.NewContext(nil, flags, nil)
-	cliCtx.Set(cli.FlagPkgName, "hansel-breadcrumb")
-	cliCtx.Set(cli.FlagPkgVersion, "1.0.0")
 
-	return cliCtx
+	// Run with test arguments
+	args := []string{
+		"test",
+		"--name", "hansel-breadcrumb",
+		"--version", "1.0.0",
+	}
+
+	err := wrapperCmd.Run(context.Background(), args)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	// Return the command with parsed flags
+	return capturedCmd
 }


### PR DESCRIPTION
Upgrade CLI library to new major version.

<details>
<summary>proompt</summary>

claude-4-opus

```
This app is pretty simple but I wanted to be using this version of the library: `github.com/urfave/cli/v3`

Something changed in the action and subcommand structure? I don't know, read the release notes, bud.
```
</details>

# Related

- Discovered https://github.com/Shopify/hansel/pull/365

